### PR TITLE
fixed iOS duration

### DIFF
--- a/RNMusicMetadata/RNMusicMetadata.m
+++ b/RNMusicMetadata/RNMusicMetadata.m
@@ -55,11 +55,10 @@ RCT_EXPORT_METHOD(getMetadata:(NSArray *)uris resolver:(RCTPromiseResolveBlock)r
         }
     }
 
-    NSURL *assetURL = [NSURL fileURLWithPath:uri];
-    AVAudioPlayer *audioPlayer = [[AVAudioPlayer alloc] initWithContentsOfURL:assetURL error:nil];
-    NSNumber *duration = [NSNumber numberWithDouble:[audioPlayer duration]];
+    CMTime audioDuration = asset.duration;
+    NSNumber *duration = [NSNumber numberWithFloat:CMTimeGetSeconds(audioDuration)];
     [songDictionary setValue:duration forKey:@"duration"];
-
+    
     [songDictionary setValue:uri forKey:@"uri"];
 
     return songDictionary;


### PR DESCRIPTION
Getting duration with AVAudioPlayer is async and should not be used. Instead use AVAsset.
Fixes [#10](https://github.com/venepe/react-native-music-metadata/issues/10)